### PR TITLE
Bylundarn/model

### DIFF
--- a/Source/Models/Token.swift
+++ b/Source/Models/Token.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public class Token {
-    let accessToken: String
+    public let accessToken: String
     let type: String
     let expires: Date
     let created: Date

--- a/Source/Models/Vehicle.swift
+++ b/Source/Models/Vehicle.swift
@@ -4,22 +4,19 @@ public class Vehicle {
     enum State: String {
         case online
     }
-    let color: String
+    let color: String?
     let displayName: String?
     let identifier: Int
-    let optionCodes: [String]
-    let userIdentifier: Int
+    let optionCodes: String
+    let userIdentifier: Int?
     let vehicleIdentifier: Int
     let vin: String
     let tokens: [String]
     let state: State
 
     init?(dictionary: [String: AnyObject]) {
-        guard let color = dictionary["color"] as? String,
-            let displayName = dictionary["dictionary"] as? String,
-            let identifier = dictionary["id"] as? Int,
-            let optionCodes = dictionary["option_codes"] as? [String],
-            let userIdentifier = dictionary["user_id"] as? Int,
+        guard let identifier = dictionary["id"] as? Int,
+            let optionCodes = dictionary["option_codes"] as? String,
             let vehicleIdentifier = dictionary["vehicle_id"] as? Int,
             let vin = dictionary["vin"] as? String,
             let tokens = dictionary["tokens"] as? [String],
@@ -27,11 +24,11 @@ public class Vehicle {
             let state = State(rawValue: stateString) else {
                 return nil
         }
-        self.color = color
-        self.displayName = displayName
+        self.displayName = dictionary["display_name"] as? String
+        self.color = dictionary["color"] as? String
+        self.userIdentifier = dictionary["user_id"] as? Int
         self.identifier = identifier
         self.optionCodes = optionCodes
-        self.userIdentifier = userIdentifier
         self.vehicleIdentifier = vehicleIdentifier
         self.vin = vin
         self.tokens = tokens

--- a/Tesla-API.xcodeproj/project.pbxproj
+++ b/Tesla-API.xcodeproj/project.pbxproj
@@ -658,6 +658,7 @@
 		FC48F9651F1E7E1E00D2400B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
@@ -680,6 +681,7 @@
 		FC48F9661F1E7E1E00D2400B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_IDENTITY = "-";
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
**Embedd swift standard libraries in project**
Fixing missing libswiftSwiftOnoneSupport.dylib at runtime.

**Make `accessToken` public**
So it can be used outside the framework, when calling other functions

**Change some optionals and types**
To confirm to the observered response:
`color` came back as `null`
`userIdentifier` came back as `null`
`optionCodes` is a comma separated list. Could still be interpreted as an array.
fixed the key for `displayName`

